### PR TITLE
fix: PyTorch deprecation warnings and add .env configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,13 @@
+# CosyVoice Environment Configuration
+# This file is sourced by rust/start-server.sh
+#
+# IMPORTANT: CosyVoice3 (Fun-CosyVoice3-0.5B) requires prompt_audio for ALL
+# synthesis requests. There is no SFT mode with pre-trained speaker embeddings.
+# You must always provide a reference audio file for voice cloning.
+
+# Library path for libpython (required for PyO3 integration)
+# The PROJECT_ROOT variable is set by start-server.sh before sourcing this file
+LD_LIBRARY_PATH_EXTRA=".pixi/envs/default/lib"
+
+# Model directory (can be overridden via COSYVOICE_MODEL_DIR env var)
+# COSYVOICE_MODEL_DIR="pretrained_models/Fun-CosyVoice3-0.5B"

--- a/rust/start-server.sh
+++ b/rust/start-server.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# CosyVoice Rust Server Startup Script
+#
+# This script sets up the correct Python environment for the Rust server
+# which uses PyO3 to bridge to CosyVoice Python backend.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_ROOT"
+
+# Load environment configuration from .env if present
+if [[ -f "$PROJECT_ROOT/.env" ]]; then
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT/.env"
+    echo "Loaded environment from .env"
+fi
+
+# Set up library path for libpython (using .env value or default)
+LD_LIBRARY_PATH_EXTRA="${LD_LIBRARY_PATH_EXTRA:-.pixi/envs/default/lib}"
+export LD_LIBRARY_PATH="$PROJECT_ROOT/$LD_LIBRARY_PATH_EXTRA:${LD_LIBRARY_PATH:-}"
+
+echo "Starting CosyVoice Rust server..."
+export COSYVOICE_MODEL_DIR="${COSYVOICE_MODEL_DIR:-pretrained_models/Fun-CosyVoice3-0.5B}"
+echo "  Model dir: $COSYVOICE_MODEL_DIR"
+echo "  LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
+
+# Use pixi run to ensure correct Python environment
+exec pixi run "$SCRIPT_DIR/target/release/cosyvoice-server" "$@"


### PR DESCRIPTION
## Summary
Fixes PyTorch deprecation warnings and externalizes environment configuration.

## Changes
### PyTorch Deprecation Fixes
- Fixed `torch.load` FutureWarning by adding `weights_only=True` parameter (3 locations in `model.py`)
- Fixed `torch.cuda.amp.autocast` deprecation by using new `torch.amp.autocast("cuda", ...)` API (2 locations in `model.py`)

### Environment Configuration
- Created `.env` file with `LD_LIBRARY_PATH_EXTRA` configuration
- Updated `rust/start-server.sh` to source `.env` file
- Library paths are now externalized and configurable

### Documentation
- Documented CosyVoice3 `prompt_audio` requirement in `session_summary.md`
- Explained that CosyVoice3 has no SFT mode - all synthesis requires a prompt audio file

## Testing
- [ ] Verify server starts without deprecation warnings
- [ ] Confirm model loading works with `weights_only=True`

Closes #22
Part of #21