### PR TITLE
feat: Load .env from Rust server and organize output files

### DIFF
--- a/.env
+++ b/.env
@@ -1,13 +1,16 @@
 # CosyVoice Environment Configuration
-# This file is sourced by rust/start-server.sh
+#
+# This file is loaded by the Rust server on startup via dotenvy.
+# Place any environment variables here that should be available to the server.
+#
+# NOTE: LD_LIBRARY_PATH is NOT loaded from here because the dynamic linker
+# needs it BEFORE the Rust binary loads. It's set in rust/start-server.sh.
 #
 # IMPORTANT: CosyVoice3 (Fun-CosyVoice3-0.5B) requires prompt_audio for ALL
 # synthesis requests. There is no SFT mode with pre-trained speaker embeddings.
-# You must always provide a reference audio file for voice cloning.
-
-# Library path for libpython (required for PyO3 integration)
-# The PROJECT_ROOT variable is set by start-server.sh before sourcing this file
-LD_LIBRARY_PATH_EXTRA=".pixi/envs/default/lib"
 
 # Model directory (can be overridden via COSYVOICE_MODEL_DIR env var)
-# COSYVOICE_MODEL_DIR="pretrained_models/Fun-CosyVoice3-0.5B"
+# COSYVOICE_MODEL_DIR=pretrained_models/Fun-CosyVoice3-0.5B
+
+# Log level for the server (default: info)
+# RUST_LOG=cosyvoice_server=debug

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,11 @@ rust/target/
 *.aac
 *.mp3
 
+# output directory (keep structure, ignore generated files)
+output/*
+!output/.gitkeep
+!output/README.md
+
 # train/inference files
 *.pt
 pretrained_models/*

--- a/example.py
+++ b/example.py
@@ -20,6 +20,7 @@ The default reference voice is the interstellar-tars voice clip.
 """
 
 import sys
+from pathlib import Path
 
 sys.path.append("third_party/Matcha-TTS")
 
@@ -30,6 +31,9 @@ from cosyvoice.cli.cosyvoice import AutoModel
 # =============================================================================
 # Default Voice Cloning Configuration
 # =============================================================================
+
+# Output directory for generated audio files
+OUTPUT_DIR = Path("output")
 
 # Reference voice clip for voice cloning
 DEFAULT_PROMPT_WAV = "./asset/interstellar-tars-01-resemble-denoised.wav"
@@ -79,8 +83,11 @@ def voice_cloning_example():
                 tts_text, full_prompt_text, DEFAULT_PROMPT_WAV, stream=False
             )
         ):
-            output_path = f"output_voice_clone_{idx}_{i}.wav"
-            torchaudio.save(output_path, output["tts_speech"], cosyvoice.sample_rate)
+            OUTPUT_DIR.mkdir(exist_ok=True)
+            output_path = OUTPUT_DIR / f"voice_clone_{idx}_{i}.wav"
+            torchaudio.save(
+                str(output_path), output["tts_speech"], cosyvoice.sample_rate
+            )
             print(f"   💾 Saved: {output_path}")
 
     print("\n✨ Voice cloning complete!")

--- a/output/README.md
+++ b/output/README.md
@@ -1,0 +1,5 @@
+# Output Directory
+
+This directory contains generated audio files from CosyVoice synthesis.
+
+Files in this directory are git-ignored. The `.gitkeep` file ensures the directory exists in version control.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -314,6 +314,7 @@ dependencies = [
  "anyhow",
  "axum",
  "bytes",
+ "dotenvy",
  "hound",
  "metrics",
  "metrics-exporter-prometheus",
@@ -354,6 +355,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dunce"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -47,6 +47,7 @@ tikv-jemallocator = "0.6"
 # Utilities
 num_cpus = "1.16"
 anyhow = "1.0"
+dotenvy = "0.15"
 
 [profile.release]
 lto = "thin"

--- a/rust/server/Cargo.toml
+++ b/rust/server/Cargo.toml
@@ -24,6 +24,7 @@ tikv-jemallocator.workspace = true
 thiserror.workspace = true
 hound.workspace = true
 anyhow.workspace = true
+dotenvy.workspace = true
 
 # Additional
 bytes = "1.9"

--- a/rust/server/src/main.rs
+++ b/rust/server/src/main.rs
@@ -38,6 +38,14 @@ struct AppState {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Load .env file from current directory (project root)
+    // start-server.sh cd's to project root before running binary
+    match dotenvy::from_filename(".env") {
+        Ok(path) => eprintln!("Loaded environment from: {}", path.display()),
+        Err(e) if e.not_found() => eprintln!("No .env file found (this is OK)"),
+        Err(e) => eprintln!("Warning: Could not load .env: {}", e),
+    }
+
     // Initialize tracing
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer().with_target(true))


### PR DESCRIPTION
Loads .env file from Rust server via dotenvy, organizes output files into dedicated directory. Closes #24