### PR TITLE
chore: Remove Matcha-TTS path dependencies from scripts

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,8 +1,11 @@
 ## ModuleNotFoundError: No module named 'matcha'
 
-Matcha-TTS is a third_party module. Please check `third_party` directory. If there is no `Matcha-TTS`, execute `git submodule update --init --recursive`.
+**Update (2026-01)**: The `third_party/Matcha-TTS` dependency is no longer required for inference. The necessary components have been implemented in `cosyvoice/compat/matcha_compat.py`.
 
-run `export PYTHONPATH=third_party/Matcha-TTS` if you want to use `from cosyvoice.cli.cosyvoice import CosyVoice` in python script.
+If you still encounter this error with older code, you have two options:
+
+1. **Recommended**: Update your code to remove `sys.path.append("third_party/Matcha-TTS")` - it's no longer needed.
+2. **Legacy**: If using the third_party module, execute `git submodule update --init --recursive` and set `export PYTHONPATH=third_party/Matcha-TTS`.
 
 ## cannot find resource.zip or cannot unzip resource.zip
 

--- a/benchmark_performance.py
+++ b/benchmark_performance.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
-import sys
 import time
 
 import numpy as np
 import torch
 
-# Add third_party to path
-sys.path.append("third_party/Matcha-TTS")
+# Note: Matcha-TTS path no longer needed - using cosyvoice.compat.matcha_compat
 from cosyvoice.cli.cosyvoice import AutoModel
 
 

--- a/example.py
+++ b/example.py
@@ -19,11 +19,9 @@ This example demonstrates zero-shot voice cloning using the Fun-CosyVoice3-0.5B-
 The default reference voice is the interstellar-tars voice clip.
 """
 
-import sys
 from pathlib import Path
 
-sys.path.append("third_party/Matcha-TTS")
-
+# Note: Matcha-TTS path no longer needed - using cosyvoice.compat.matcha_compat
 import torchaudio
 
 from cosyvoice.cli.cosyvoice import AutoModel

--- a/experiment_vocoder_params.py
+++ b/experiment_vocoder_params.py
@@ -6,9 +6,8 @@ Tests different NSF (Neural Source Filter) parameter combinations
 to find optimal settings for audio quality.
 """
 
-import sys
 
-sys.path.append("third_party/Matcha-TTS")
+# Note: Matcha-TTS path no longer needed - using cosyvoice.compat.matcha_compat
 
 import os
 from pathlib import Path


### PR DESCRIPTION
## Summary

Removes the now-unnecessary `sys.path.append("third_party/Matcha-TTS")` from various Python scripts.

Since PR #48 introduced `cosyvoice/compat/matcha_compat.py`, the Matcha-TTS third-party dependency is no longer required for inference.

## Files Modified

| File | Change |
|------|--------|
| `example.py` | Remove path append |
| `benchmark_performance.py` | Remove path append |
| `experiment_vocoder_params.py` | Remove path append |
| `FAQ.md` | Update documentation |

## Notes

- The `third_party/Matcha-TTS` directory is still retained for reference/training use
- All runtime imports now go through `cosyvoice.compat.matcha_compat`