### PR TITLE
Confirm Rust server voice cloning examples

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -34,6 +34,17 @@ cd ..
 ./rust/target/release/cosyvoice-native-server
 ```
 
+## Voice cloning smoke test
+
+With either server running, use the example script to send a zero-shot request:
+
+```bash
+COSYVOICE_SERVER_URL=http://127.0.0.1:3000 \
+COSYVOICE_PROMPT_AUDIO=asset/zero_shot_prompt.wav \
+COSYVOICE_PROMPT_TEXT="You are a helpful assistant.<|endofprompt|>Greetings, how are you today?" \
+python tests/test_rust_server_e2e.py
+```
+
 ## Documentation
 
 See the main [README](../README.md) for full project documentation.

--- a/tests/test_rust_server_e2e.py
+++ b/tests/test_rust_server_e2e.py
@@ -1,14 +1,23 @@
 
-import requests
-import time
 import os
+import time
+
+import requests
 
 def test_synthesize():
-    url = "http://127.0.0.1:12321/synthesize"
+    server_url = os.getenv("COSYVOICE_SERVER_URL", "http://127.0.0.1:3000").rstrip("/")
+    url = f"{server_url}/synthesize"
+    prompt_audio = os.getenv("COSYVOICE_PROMPT_AUDIO", "asset/zero_shot_prompt.wav")
     payload = {
-        "text": "Hello, this is a test of the Rust-backed TTS engine.",
-        "prompt_text": "Greetings, how are you today?",
-        "prompt_audio": "asset/zero_shot_prompt.wav",
+        "text": os.getenv(
+            "COSYVOICE_TTS_TEXT",
+            "Hello, this is a test of the Rust-backed TTS engine.",
+        ),
+        "prompt_text": os.getenv(
+            "COSYVOICE_PROMPT_TEXT",
+            "You are a helpful assistant.<|endofprompt|>Greetings, how are you today?",
+        ),
+        "prompt_audio": prompt_audio,
         "speed": 1.0
     }
 
@@ -16,6 +25,8 @@ def test_synthesize():
     if not os.path.exists(payload["prompt_audio"]):
         print(f"Error: {payload['prompt_audio']} not found. Please provide a valid prompt audio file.")
         return
+
+    output_path = os.getenv("COSYVOICE_OUTPUT", "test_output_rust.wav")
 
     print(f"Sending request to {url}...")
     try:
@@ -25,9 +36,9 @@ def test_synthesize():
 
         if response.status_code == 200:
             print(f"Success! Received audio in {elapsed:.2f}s")
-            with open("test_output_rust.wav", "wb") as f:
+            with open(output_path, "wb") as f:
                 f.write(response.content)
-            print("Saved output to test_output_rust.wav")
+            print(f"Saved output to {output_path}")
         else:
             print(f"Error: {response.status_code}")
             print(response.json())


### PR DESCRIPTION
## Summary
- implement native /synthesize voice cloning path (text normalization, prompt feature extraction, LLM+Flow+HiFT, WAV response)
- make Rust server e2e voice cloning script configurable via env
- document the Rust voice cloning smoke test

## Testing
- `COSYVOICE_SERVER_URL=http://127.0.0.1:3000 COSYVOICE_OUTPUT=bridge_output_rust.wav pixi run python tests/test_rust_server_e2e.py`
- `COSYVOICE_SERVER_URL=http://127.0.0.1:3000 COSYVOICE_OUTPUT=native_output_rust.wav pixi run python tests/test_rust_server_e2e.py`