### PR TITLE
perf: optimize TTS inference paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ pretrained_models/*
 verify_output*.txt
 rust/server/*.log
 
+# Codex agent state
+/.agent/
+
 # Local task/plan artifacts (if any leaked to root)
 task.md
 implementation_plan.md
@@ -89,3 +92,8 @@ third_party/ug/
 
 # Rust internal debug scripts
 rust/server/check_*.py
+
+# Local debug artifacts
+/python_hift_output.wav
+/tests/hift_parity/python_intermediates.safetensors
+/tests/python_hift_debug_audio.wav

--- a/benchmark_performance.py
+++ b/benchmark_performance.py
@@ -1,92 +1,192 @@
 #!/usr/bin/env python3
+import argparse
+import json
+import statistics
 import time
 
-import numpy as np
 import torch
 
 # Note: Matcha-TTS path no longer needed - using cosyvoice.compat.matcha_compat
 from cosyvoice.cli.cosyvoice import AutoModel
 
 
-def benchmark_tts(model_dir, test_text, prompt_text, prompt_wav, iterations=3):
-    print(f"\n🚀 Starting benchmark for model: {model_dir}")
+def _parse_args():
+    parser = argparse.ArgumentParser(description="Benchmark CosyVoice TTS performance.")
+    parser.add_argument(
+        "--model-dir",
+        default="pretrained_models/Fun-CosyVoice3-0.5B",
+    )
+    parser.add_argument(
+        "--prompt-wav",
+        default="./asset/interstellar-tars-01-resemble-denoised.wav",
+    )
+    parser.add_argument(
+        "--prompt-text",
+        default=(
+            "Eight months to Mars. Counter-orbital slingshot around 14 months to Saturn. "
+            "Nothing's changed on that."
+        ),
+    )
+    parser.add_argument(
+        "--prompt-prefix",
+        default="You are a helpful assistant. Please speak in English.<|endofprompt|>",
+    )
+    parser.add_argument(
+        "--test-text",
+        default=(
+            "The quick brown fox jumps over the lazy dog. Performance optimization is "
+            "the key to a better user experience."
+        ),
+    )
+    parser.add_argument("--iterations", type=int, default=3)
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--stream", action="store_true")
+    parser.add_argument("--load-trt", action="store_true")
+    parser.add_argument("--load-vllm", action="store_true")
+    parser.add_argument("--fp16", action="store_true")
+    parser.add_argument("--trt-concurrent", type=int, default=1)
+    parser.add_argument("--use-rl", action="store_true")
+    parser.add_argument("--output", default="")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
 
-    # Measure model loading time
-    start_load = time.time()
-    cosyvoice = AutoModel(model_dir=model_dir)
-    load_time = time.time() - start_load
-    print(f"📦 Model Load Time: {load_time:.2f}s")
 
-    metrics = {
-        "ftl": [],  # First Token Latency
-        "rtf": [],  # Real Time Factor
-        "throughput": [],  # Audio seconds per generation second
-        "total_time": [],
+def _stats(values):
+    if not values:
+        return {"avg": None, "median": None, "min": None, "max": None}
+    return {
+        "avg": statistics.mean(values),
+        "median": statistics.median(values),
+        "min": min(values),
+        "max": max(values),
     }
 
-    # Warmup
-    print("🔥 Warming up (compilation might take a while)...")
-    for _ in range(2):
+
+def benchmark_tts(
+    model_dir,
+    test_text,
+    prompt_text,
+    prompt_wav,
+    iterations=3,
+    warmup=2,
+    stream=True,
+    load_trt=False,
+    load_vllm=False,
+    fp16=False,
+    trt_concurrent=1,
+    use_rl=False,
+):
+    print(f"Starting benchmark for model: {model_dir}")
+
+    start_load = time.perf_counter()
+    cosyvoice = AutoModel(
+        model_dir=model_dir,
+        load_trt=load_trt,
+        load_vllm=load_vllm,
+        fp16=fp16,
+        trt_concurrent=trt_concurrent,
+        use_rl=use_rl,
+    )
+    load_time = time.perf_counter() - start_load
+    print(f"Model load time: {load_time:.2f}s")
+
+    metrics = {
+        "ftl": [],
+        "rtf": [],
+        "throughput": [],
+        "total_time": [],
+        "audio_secs": [],
+    }
+
+    print("Warming up...")
+    for _ in range(warmup):
         for _ in cosyvoice.inference_zero_shot(
-            test_text, prompt_text, prompt_wav, stream=True
+            test_text, prompt_text, prompt_wav, stream=stream
         ):
             pass
 
-    print(f"🏃 Running {iterations} iterations...")
+    print(f"Running {iterations} iterations...")
     for i in range(iterations):
-        start_gen = time.time()
+        start_gen = time.perf_counter()
         first_token_time = None
-        total_audio_len = 0
+        total_audio_len = 0.0
 
         for output in cosyvoice.inference_zero_shot(
-            test_text, prompt_text, prompt_wav, stream=True
+            test_text, prompt_text, prompt_wav, stream=stream
         ):
             if first_token_time is None:
-                first_token_time = time.time() - start_gen
+                first_token_time = time.perf_counter() - start_gen
 
             audio_len = output["tts_speech"].shape[1] / cosyvoice.sample_rate
             total_audio_len += audio_len
 
-        end_gen = time.time()
-        total_gen_time = end_gen - start_gen
+        total_gen_time = time.perf_counter() - start_gen
 
         if total_audio_len > 0:
             rtf = total_gen_time / total_audio_len
             throughput = total_audio_len / total_gen_time
-            metrics["rtf"].append(rtf)
-            metrics["throughput"].append(throughput)
         else:
-            metrics["rtf"].append(0)
-            metrics["throughput"].append(0)
+            rtf = 0.0
+            throughput = 0.0
 
         metrics["ftl"].append(first_token_time)
+        metrics["rtf"].append(rtf)
+        metrics["throughput"].append(throughput)
         metrics["total_time"].append(total_gen_time)
+        metrics["audio_secs"].append(total_audio_len)
 
         print(
-            f"Iteration {i + 1}: FTL={first_token_time:.3f}s, RTF={rtf:.3f}, Audio={total_audio_len:.2f}s"
+            f"Iteration {i + 1}: FTL={first_token_time:.3f}s, "
+            f"RTF={rtf:.3f}, Audio={total_audio_len:.2f}s"
         )
 
-    # Calculate averages
-    print("\n" + "=" * 40)
-    print("📊 Benchmark Results (Averages)")
-    print("=" * 40)
-    print(f"First Token Latency: {np.mean(metrics['ftl']):.3f}s")
-    print(f"Real-Time Factor:  {np.mean(metrics['rtf']):.3f}")
-    print(f"Throughput:         {np.mean(metrics['throughput']):.2f}s/s")
-    print(f"Avg Gen Time:       {np.mean(metrics['total_time']):.2f}s")
-    print("=" * 40)
+    summary = {
+        "ftl": _stats(metrics["ftl"]),
+        "rtf": _stats(metrics["rtf"]),
+        "throughput": _stats(metrics["throughput"]),
+        "total_time": _stats(metrics["total_time"]),
+        "audio_secs": _stats(metrics["audio_secs"]),
+    }
+
+    print("\nBenchmark Results (Averages)")
+    print(f"First Token Latency: {summary['ftl']['avg']:.3f}s")
+    print(f"Real-Time Factor:    {summary['rtf']['avg']:.3f}")
+    print(f"Throughput:          {summary['throughput']['avg']:.2f}s/s")
+    print(f"Avg Gen Time:        {summary['total_time']['avg']:.2f}s")
 
     if torch.cuda.is_available():
         print(f"GPU Memory: {torch.cuda.max_memory_allocated() / 1024**3:.2f} GB")
 
+    return {
+        "model_dir": model_dir,
+        "load_time": load_time,
+        "metrics": metrics,
+        "summary": summary,
+    }
+
 
 if __name__ == "__main__":
-    MODEL_DIR = "pretrained_models/Fun-CosyVoice3-0.5B"
-    PROMPT_WAV = "./asset/interstellar-tars-01-resemble-denoised.wav"
-    PROMPT_TEXT = "Eight months to Mars. Counter-orbital slingshot around 14 months to Saturn. Nothing's changed on that."
-    TEST_TEXT = "The quick brown fox jumps over the lazy dog. Performance optimization is the key to a better user experience."
-    PROMPT_PREFIX = (
-        "You are a helpful assistant. Please speak in English.<|endofprompt|>"
+    args = _parse_args()
+    result = benchmark_tts(
+        model_dir=args.model_dir,
+        test_text=args.test_text,
+        prompt_text=args.prompt_prefix + args.prompt_text,
+        prompt_wav=args.prompt_wav,
+        iterations=args.iterations,
+        warmup=args.warmup,
+        stream=args.stream,
+        load_trt=args.load_trt,
+        load_vllm=args.load_vllm,
+        fp16=args.fp16,
+        trt_concurrent=args.trt_concurrent,
+        use_rl=args.use_rl,
     )
-
-    benchmark_tts(MODEL_DIR, TEST_TEXT, PROMPT_PREFIX + PROMPT_TEXT, PROMPT_WAV)
+    if args.json or args.output:
+        output = json.dumps(result, indent=2)
+        if args.json:
+            print("\nJSON Result")
+            print(output)
+        if args.output:
+            with open(args.output, "w", encoding="utf-8") as f:
+                f.write(output)
+                f.write("\n")

--- a/cosyvoice/cli/cosyvoice.py
+++ b/cosyvoice/cli/cosyvoice.py
@@ -216,31 +216,32 @@ class CosyVoice3:
         ):
             if (not isinstance(i, Generator)) and len(i) < 0.5 * len(prompt_text):
                 logging.warning(
-                    "synthesis text {} too short than prompt text {}, this may lead to bad performance".format(
-                        i, prompt_text
-                    )
+                    "synthesis text %s too short than prompt text %s, this may lead to bad performance",
+                    i,
+                    prompt_text,
                 )
             model_input = self.frontend.frontend_zero_shot(
                 i, prompt_text, prompt_wav, self.sample_rate, zero_shot_spk_id
             )
-            start_time = time.time()
-            logging.info("synthesis text {}".format(i))
+            start_time = time.perf_counter()
+            logging.info("synthesis text %s", i)
             for model_output in self.model.tts(
                 **model_input, stream=stream, speed=speed
             ):
                 speech_len = model_output["tts_speech"].shape[1] / self.sample_rate
-                inference_time = time.time() - start_time
+                inference_time = time.perf_counter() - start_time
                 if speech_len > 0:
                     rtf = inference_time / speech_len
                     logging.info(
-                        "yield speech len {:.2f}s, inference time {:.3f}s, rtf {:.3f}".format(
-                            speech_len, inference_time, rtf
-                        )
+                        "yield speech len %.2fs, inference time %.3fs, rtf %.3f",
+                        speech_len,
+                        inference_time,
+                        rtf,
                     )
                 else:
                     logging.debug("yield speech len is 0, skipping rtf calculation")
                 yield model_output
-                start_time = time.time()
+                start_time = time.perf_counter()
 
     def inference_cross_lingual(
         self,
@@ -273,22 +274,22 @@ class CosyVoice3:
             model_input = self.frontend.frontend_cross_lingual(
                 i, prompt_wav, self.sample_rate, zero_shot_spk_id
             )
-            start_time = time.time()
-            logging.info("synthesis text {}".format(i))
+            start_time = time.perf_counter()
+            logging.info("synthesis text %s", i)
             for model_output in self.model.tts(
                 **model_input, stream=stream, speed=speed
             ):
                 speech_len = model_output["tts_speech"].shape[1] / self.sample_rate
                 if speech_len > 0:
                     logging.info(
-                        "yield speech len {}, rtf {}".format(
-                            speech_len, (time.time() - start_time) / speech_len
-                        )
+                        "yield speech len %s, rtf %s",
+                        speech_len,
+                        (time.perf_counter() - start_time) / speech_len,
                     )
                 else:
                     logging.debug("yield speech len is 0, skipping rtf calculation")
                 yield model_output
-                start_time = time.time()
+                start_time = time.perf_counter()
 
     def inference_instruct2(
         self,
@@ -323,22 +324,22 @@ class CosyVoice3:
             model_input = self.frontend.frontend_instruct2(
                 i, instruct_text, prompt_wav, self.sample_rate, zero_shot_spk_id
             )
-            start_time = time.time()
-            logging.info("synthesis text {}".format(i))
+            start_time = time.perf_counter()
+            logging.info("synthesis text %s", i)
             for model_output in self.model.tts(
                 **model_input, stream=stream, speed=speed
             ):
                 speech_len = model_output["tts_speech"].shape[1] / self.sample_rate
                 if speech_len > 0:
                     logging.info(
-                        "yield speech len {}, rtf {}".format(
-                            speech_len, (time.time() - start_time) / speech_len
-                        )
+                        "yield speech len %s, rtf %s",
+                        speech_len,
+                        (time.perf_counter() - start_time) / speech_len,
                     )
                 else:
                     logging.debug("yield speech len is 0, skipping rtf calculation")
                 yield model_output
-                start_time = time.time()
+                start_time = time.perf_counter()
 
 
 def AutoModel(**kwargs):

--- a/rust/bridge-server/src/main.rs
+++ b/rust/bridge-server/src/main.rs
@@ -11,15 +11,10 @@ use axum::{
 };
 use metrics::{counter, histogram};
 use metrics_exporter_prometheus::PrometheusBuilder;
-use std::{
-    env,
-    net::SocketAddr,
-    sync::Arc,
-    time::Instant,
-};
+use std::{env, net::SocketAddr, sync::Arc, time::Instant};
 use tokio::signal;
 use tower_http::trace::TraceLayer;
-use tracing::{info, error, warn};
+use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use shared::{config, ErrorResponse, HealthResponse, SynthesizeRequest};
@@ -64,8 +59,8 @@ async fn main() -> anyhow::Result<()> {
     info!("Prometheus metrics recorder installed");
 
     // Get model directory from env or use default
-    let model_dir = env::var("COSYVOICE_MODEL_DIR")
-        .unwrap_or_else(|_| config::DEFAULT_MODEL_DIR.to_string());
+    let model_dir =
+        env::var("COSYVOICE_MODEL_DIR").unwrap_or_else(|_| config::DEFAULT_MODEL_DIR.to_string());
 
     // Initialize TTS engine
     info!(model_dir = %model_dir, "Initializing CosyVoice TTS engine...");
@@ -149,9 +144,7 @@ async fn synthesize_handler(
                 .synthesize_zero_shot(&text, &prompt_audio, prompt_text, speed)
         } else {
             // Instruct mode with default instruction
-            let instruct = speaker
-                .as_deref()
-                .unwrap_or("Speak naturally in English.");
+            let instruct = speaker.as_deref().unwrap_or("Speak naturally in English.");
             state
                 .tts
                 .synthesize_instruct(&text, instruct, &prompt_audio, speed)
@@ -319,8 +312,8 @@ fn ensure_library_path() -> anyhow::Result<()> {
     let _ = dotenvy::from_filename(".env");
 
     // Get the extra library path from .env (default to pixi env)
-    let lib_path_extra = env::var("LD_LIBRARY_PATH_EXTRA")
-        .unwrap_or_else(|_| ".pixi/envs/default/lib".to_string());
+    let lib_path_extra =
+        env::var("LD_LIBRARY_PATH_EXTRA").unwrap_or_else(|_| ".pixi/envs/default/lib".to_string());
 
     // Resolve to absolute path
     let lib_path_abs = cwd.join(&lib_path_extra);

--- a/rust/bridge-server/src/tts.rs
+++ b/rust/bridge-server/src/tts.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+#[allow(clippy::enum_variant_names)]
 pub enum TtsError {
     #[error("TTS initialization failed: {0}")]
     InitError(String),

--- a/rust/client/src/main.rs
+++ b/rust/client/src/main.rs
@@ -7,7 +7,7 @@ use reqwest::Client;
 use std::io::Write;
 use std::path::PathBuf;
 use std::time::Instant;
-use tracing::{info, error};
+use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use shared::SynthesizeRequest;
@@ -108,11 +108,7 @@ async fn main() -> anyhow::Result<()> {
     let start = Instant::now();
     let url = format!("{}/synthesize", args.server);
 
-    let response = client
-        .post(&url)
-        .json(&request)
-        .send()
-        .await?;
+    let response = client.post(&url).json(&request).send().await?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -147,7 +143,11 @@ async fn main() -> anyhow::Result<()> {
         std::fs::write(output_path, &audio_data)?;
         info!(path = %output_path.display(), "Saved audio file");
 
-        println!("✓ Synthesized {} chars in {:.2}s", args.text.len(), elapsed.as_secs_f32());
+        println!(
+            "✓ Synthesized {} chars in {:.2}s",
+            args.text.len(),
+            elapsed.as_secs_f32()
+        );
         println!("  Audio duration: {:.2}s", audio_duration);
         println!("  RTF: {:.2}x", audio_duration / elapsed.as_secs_f32());
         println!("  Output: {}", output_path.display());

--- a/rust/native-server/src/audio.rs
+++ b/rust/native-server/src/audio.rs
@@ -444,7 +444,13 @@ pub fn stft(
 /// Returns mel spectrogram as (num_mels, n_frames) array with log compression.
 pub fn mel_spectrogram_ndarray(audio: &[f32], config: &MelConfig) -> Result<Array2<f32>> {
     // Compute STFT magnitude
-    let spec = stft(audio, config.n_fft, config.hop_size, config.win_size, config.center)?;
+    let spec = stft(
+        audio,
+        config.n_fft,
+        config.hop_size,
+        config.win_size,
+        config.center,
+    )?;
 
     // Create mel filterbank
     let mel_basis = create_mel_filterbank(config);
@@ -783,7 +789,12 @@ pub fn upsample_2x_cubic(samples: &[f32]) -> Vec<f32> {
 
         // Cubic interpolation at t=0.5
         let t = 0.5f32;
-        let interpolated = s_0 + 0.5 * t * (s_1 - s_m1 + t * (2.0 * s_m1 - 5.0 * s_0 + 4.0 * s_1 - s_2 + t * (3.0 * (s_0 - s_1) + s_2 - s_m1)));
+        let interpolated = s_0
+            + 0.5
+                * t
+                * (s_1 - s_m1
+                    + t * (2.0 * s_m1 - 5.0 * s_0 + 4.0 * s_1 - s_2
+                        + t * (3.0 * (s_0 - s_1) + s_2 - s_m1)));
         output.push(interpolated);
     }
 
@@ -872,8 +883,14 @@ mod tests {
         let audio: Vec<f32> = (0..24000).map(|i| (i as f32 * 0.01).sin()).collect();
         let config = MelConfig::inference();
 
-        let spec = stft(&audio, config.n_fft, config.hop_size, config.win_size, config.center)
-            .expect("STFT should succeed");
+        let spec = stft(
+            &audio,
+            config.n_fft,
+            config.hop_size,
+            config.win_size,
+            config.center,
+        )
+        .expect("STFT should succeed");
 
         // Check output shape
         assert_eq!(spec.ncols(), config.n_fft / 2 + 1);

--- a/rust/native-server/src/bin/native_example.rs
+++ b/rust/native-server/src/bin/native_example.rs
@@ -59,9 +59,12 @@ fn main() -> Result<()> {
     let device = Device::cuda_if_available(0).unwrap_or(Device::Cpu);
     println!("Using device: {:?}", device);
 
-    let mut engine = NativeTtsEngine::new(model_dir.to_string_lossy().as_ref(), Some(device.clone()))?;
+    let mut engine =
+        NativeTtsEngine::new(model_dir.to_string_lossy().as_ref(), Some(device.clone()))?;
     if engine.frontend.is_none() {
-        return Err(anyhow!("ONNX frontend failed to initialize; cannot run native example."));
+        return Err(anyhow!(
+            "ONNX frontend failed to initialize; cannot run native example."
+        ));
     }
 
     let prompt_wav = repo_root.join(DEFAULT_PROMPT_WAV_REL);
@@ -78,9 +81,11 @@ fn main() -> Result<()> {
 
     let prompt_speech_16k = audio::whisper_log_mel_spectrogram(&prompt_16k, &Device::Cpu)?;
     let prompt_fbank = audio::kaldi_fbank(&prompt_16k, 16000, &Device::Cpu)?;
-    let mut prompt_speech_24k = audio::mel_spectrogram(&prompt_24k, &MelConfig::cosyvoice3(), &device)?;
+    let mut prompt_speech_24k =
+        audio::mel_spectrogram(&prompt_24k, &MelConfig::cosyvoice3(), &device)?;
 
-    let (mut prompt_speech_tokens, speaker_embedding) = engine.process_prompt_tensors(&prompt_speech_16k, &prompt_fbank)?;
+    let (mut prompt_speech_tokens, speaker_embedding) =
+        engine.process_prompt_tensors(&prompt_speech_16k, &prompt_fbank)?;
 
     // Align prompt mel length with prompt token length (token_mel_ratio = 2)
     let mel_len = prompt_speech_24k.dim(2)?;
@@ -111,7 +116,11 @@ fn main() -> Result<()> {
     for (idx, tts_text) in texts.iter().enumerate() {
         let segments = text_normalize_english(tts_text, &tokenizer, true, true)?;
         if segments.is_empty() {
-            println!("\nSkipping empty text segment for input [{}/{}]", idx + 1, texts.len());
+            println!(
+                "\nSkipping empty text segment for input [{}/{}]",
+                idx + 1,
+                texts.len()
+            );
             continue;
         }
 
@@ -144,7 +153,8 @@ fn main() -> Result<()> {
                 25,
             )?;
 
-            let output_path = output_dir.join(format!("native_voice_clone_{}_{}.wav", idx, seg_idx));
+            let output_path =
+                output_dir.join(format!("native_voice_clone_{}_{}.wav", idx, seg_idx));
             save_wav(&output_path, &audio_samples, engine.sample_rate)?;
             let duration = audio_samples.len() as f32 / engine.sample_rate as f32;
             println!("Saved: {:?} (duration {:.2}s)", output_path, duration);

--- a/rust/native-server/src/bin/test_flow.rs
+++ b/rust/native-server/src/bin/test_flow.rs
@@ -1,6 +1,6 @@
 // Minimal test to isolate AdaLayerNormZero and DiTBlock forward issues
-use candle_core::{Device, Result, Tensor, DType};
-use candle_nn::{layer_norm_no_bias, linear, VarBuilder, Module};
+use candle_core::{DType, Device, Result, Tensor};
+use candle_nn::{layer_norm_no_bias, linear, Module, VarBuilder};
 use std::collections::HashMap;
 
 fn main() -> Result<()> {
@@ -12,12 +12,24 @@ fn main() -> Result<()> {
     let mut weights: HashMap<String, Tensor> = HashMap::new();
 
     // AdaLayerNormZero weights (attn_norm)
-    weights.insert("attn_norm.linear.weight".to_string(), Tensor::randn(0.0f32, 0.01, (6144, 1024), &device)?);
-    weights.insert("attn_norm.linear.bias".to_string(), Tensor::zeros((6144,), DType::F32, &device)?);
-    weights.insert("attn_norm.weight".to_string(), Tensor::ones((1024,), DType::F32, &device)?);
+    weights.insert(
+        "attn_norm.linear.weight".to_string(),
+        Tensor::randn(0.0f32, 0.01, (6144, 1024), &device)?,
+    );
+    weights.insert(
+        "attn_norm.linear.bias".to_string(),
+        Tensor::zeros((6144,), DType::F32, &device)?,
+    );
+    weights.insert(
+        "attn_norm.weight".to_string(),
+        Tensor::ones((1024,), DType::F32, &device)?,
+    );
 
     // ff_norm weights
-    weights.insert("ff_norm.weight".to_string(), Tensor::ones((1024,), DType::F32, &device)?);
+    weights.insert(
+        "ff_norm.weight".to_string(),
+        Tensor::ones((1024,), DType::F32, &device)?,
+    );
 
     let vb = VarBuilder::from_tensors(weights, DType::F32, &device);
 
@@ -46,7 +58,10 @@ fn main() -> Result<()> {
 
     eprintln!("\n2. Chunking emb into 6 parts");
     let chunks = emb.chunk(6, 1)?;
-    eprintln!("   chunk shapes: {:?}", chunks.iter().map(|c| c.dims()).collect::<Vec<_>>());
+    eprintln!(
+        "   chunk shapes: {:?}",
+        chunks.iter().map(|c| c.dims()).collect::<Vec<_>>()
+    );
 
     let shift_msa = chunks[0].unsqueeze(1)?;
     let scale_msa = chunks[1].unsqueeze(1)?;

--- a/rust/native-server/src/bin/test_matcha_parity.rs
+++ b/rust/native-server/src/bin/test_matcha_parity.rs
@@ -6,9 +6,9 @@
 //! Parent Issue: #44
 //! Sub-Issue: #47
 
+use anyhow::{Context, Result};
 use candle_core::{Device, Tensor};
 use std::path::Path;
-use anyhow::{Result, Context};
 
 /// Test sinusoidal embedding (timestep embedding base)
 fn test_sinusoidal_embedding(device: &Device) -> Result<()> {
@@ -22,9 +22,9 @@ fn test_sinusoidal_embedding(device: &Device) -> Result<()> {
     }
 
     let tensors = candle_core::safetensors::load(test_path, device)?;
-    let t_values = tensors.get("t_values")
-        .context("t_values not found")?;
-    let expected_emb = tensors.get("expected_emb")
+    let t_values = tensors.get("t_values").context("t_values not found")?;
+    let expected_emb = tensors
+        .get("expected_emb")
         .context("expected_emb not found")?;
 
     println!("Input t_values shape: {:?}", t_values.shape());
@@ -90,7 +90,9 @@ fn test_snake_activation(device: &Device) -> Result<()> {
     let tensors = candle_core::safetensors::load(test_path, device)?;
     let x = tensors.get("input_x").context("input_x not found")?;
     let alpha = tensors.get("alpha").context("alpha not found")?;
-    let expected_out = tensors.get("expected_out").context("expected_out not found")?;
+    let expected_out = tensors
+        .get("expected_out")
+        .context("expected_out not found")?;
 
     println!("Input x shape: {:?}", x.shape());
 
@@ -134,7 +136,9 @@ fn test_mel_spectrogram(device: &Device) -> Result<()> {
 
     let tensors = candle_core::safetensors::load(test_path, device)?;
     let test_audio = tensors.get("test_audio").context("test_audio not found")?;
-    let expected_mel = tensors.get("expected_mel").context("expected_mel not found")?;
+    let expected_mel = tensors
+        .get("expected_mel")
+        .context("expected_mel not found")?;
 
     println!("Input audio shape: {:?}", test_audio.shape());
     println!("Expected mel shape: {:?}", expected_mel.shape());
@@ -165,7 +169,8 @@ fn test_mel_spectrogram(device: &Device) -> Result<()> {
     println!("L1 error: {:.6}", l1_error);
     println!("Max error: {:.6}", max_error);
 
-    if l1_error < 1e-2 {  // Mel spectrograms can have larger variance
+    if l1_error < 1e-2 {
+        // Mel spectrograms can have larger variance
         println!("✅ PASS: Mel spectrogram parity within tolerance!");
     } else if l1_error < 0.1 {
         println!("⚠️  WARN: Mel spectrogram has moderate error (expected for FFT differences)");

--- a/rust/native-server/src/hift.rs
+++ b/rust/native-server/src/hift.rs
@@ -634,11 +634,13 @@ impl HiFTGenerator {
         let stft = crate::utils::InverseStftModule::new(
             config.istft_params_n_fft,
             config.istft_params_hop_len,
+            true,
             vb.device(),
         )?;
         let analysis_stft = crate::utils::StftModule::new(
             config.istft_params_n_fft,
             config.istft_params_hop_len,
+            true,
             vb.device(),
         )?;
 

--- a/rust/native-server/src/hift.rs
+++ b/rust/native-server/src/hift.rs
@@ -119,18 +119,14 @@ impl SineGen {
                     let current_f0 = f0_vec[offset_f0 + t];
                     let phase_step = current_f0 * mult / sampling_rate;
                     running_phase += phase_step;
-                    running_phase = running_phase % 1.0;
+                    running_phase %= 1.0;
                     let val = (running_phase * two_pi).sin() * sine_amp;
                     sine_waves_vec.push(val);
                 }
             }
         }
 
-        let sine_waves = Tensor::from_vec(
-            sine_waves_vec,
-            (b, num_harmonics, l),
-            &f0.device()
-        )?;
+        let sine_waves = Tensor::from_vec(sine_waves_vec, (b, num_harmonics, l), f0.device())?;
 
         // 4. UV
         let uv = f0.gt(self.voiced_threshold as f64)?.to_dtype(DType::F32)?;
@@ -233,10 +229,7 @@ impl SourceModuleHnNSF {
         // Check if weight_norm is on logic? generator.py: SourceModuleHnNSF uses regular Linear.
         let l_linear = candle_nn::linear(harmonic_num + 1, 1, vb.pp("l_linear"))?;
 
-        Ok(Self {
-            sine_gen,
-            l_linear,
-        })
+        Ok(Self { sine_gen, l_linear })
     }
 
     /// Forward pass with optional noise injection for parity testing.
@@ -410,10 +403,10 @@ impl F0Predictor {
                 let w = layer.weight();
                 if let Ok(flat) = w.flatten_all() {
                     if let Ok(vec) = flat.to_vec1::<f32>() {
-                         let min = vec.iter().cloned().fold(f32::INFINITY, f32::min);
-                         let max = vec.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
-                         let mean = vec.iter().sum::<f32>() / vec.len() as f32;
-                         eprintln!("    [F0Predictor] Layer 0 weight (after norm): min={:.6}, max={:.6}, mean={:.6}", min, max, mean);
+                        let min = vec.iter().cloned().fold(f32::INFINITY, f32::min);
+                        let max = vec.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+                        let mean = vec.iter().sum::<f32>() / vec.len() as f32;
+                        eprintln!("    [F0Predictor] Layer 0 weight (after norm): min={:.6}, max={:.6}, mean={:.6}", min, max, mean);
                     }
                 }
 
@@ -464,7 +457,10 @@ impl F0Predictor {
                     let max = vec.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
                     let sum: f32 = vec.iter().sum();
                     let mean = sum / vec.len() as f32;
-                    eprintln!("    Layer {} after ELU: min={:.6}, max={:.6}, mean={:.6}", i, min, max, mean);
+                    eprintln!(
+                        "    Layer {} after ELU: min={:.6}, max={:.6}, mean={:.6}",
+                        i, min, max, mean
+                    );
                 }
             }
         }
@@ -479,7 +475,10 @@ impl F0Predictor {
                 let max = vec.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
                 let sum: f32 = vec.iter().sum();
                 let mean = sum / vec.len() as f32;
-                eprintln!("    Classifier out (pre-abs): min={:.6}, max={:.6}, mean={:.6}", min, max, mean);
+                eprintln!(
+                    "    Classifier out (pre-abs): min={:.6}, max={:.6}, mean={:.6}",
+                    min, max, mean
+                );
             }
         }
 
@@ -513,12 +512,14 @@ impl HiFTGenerator {
 
         // Conv Pre
         // Fun-CosyVoice3-0.5B has kernel_size=5, padding=2
-        let conv_pre_k = if vb.pp("conv_pre").contains_tensor("weight.original1") {
-             5
-        } else if vb.pp("conv_pre").contains_tensor("parametrizations.weight.original1") {
-             5
+        let conv_pre_k = if vb.pp("conv_pre").contains_tensor("weight.original1")
+            || vb
+                .pp("conv_pre")
+                .contains_tensor("parametrizations.weight.original1")
+        {
+            5
         } else {
-             13
+            13
         };
         let conv_pre = load_conv1d(
             vb.pp("conv_pre"),
@@ -685,7 +686,10 @@ impl HiFTGenerator {
                 let max = mel_vec.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
                 let sum: f32 = mel_vec.iter().sum();
                 let mean = sum / mel_vec.len() as f32;
-                eprintln!("    input mel stats: min={:.6}, max={:.6}, mean={:.6}", min, max, mean);
+                eprintln!(
+                    "    input mel stats: min={:.6}, max={:.6}, mean={:.6}",
+                    min, max, mean
+                );
             }
         }
 
@@ -702,7 +706,10 @@ impl HiFTGenerator {
                 let max = f0_vec.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
                 let sum: f32 = f0_vec.iter().sum();
                 let mean = sum / f0_vec.len() as f32;
-                eprintln!("    F0 stats: min={:.6} Hz, max={:.6} Hz, mean={:.6} Hz", min, max, mean);
+                eprintln!(
+                    "    F0 stats: min={:.6} Hz, max={:.6} Hz, mean={:.6} Hz",
+                    min, max, mean
+                );
             }
         }
 
@@ -713,7 +720,11 @@ impl HiFTGenerator {
             .unsqueeze(3)?
             .repeat((1, 1, 1, self.f0_upsamp_scale))?
             .reshape((b, c, l * self.f0_upsamp_scale))?;
-        eprintln!("    upsampled f0 shape: {:?} (scale={})", s.shape(), self.f0_upsamp_scale);
+        eprintln!(
+            "    upsampled f0 shape: {:?} (scale={})",
+            s.shape(),
+            self.f0_upsamp_scale
+        );
 
         // 3. Source Module
         let (s_source, _, _) = self.m_source.forward(&s, None, None, None)?; // [B, 1, L_up]
@@ -726,7 +737,10 @@ impl HiFTGenerator {
                 let max = src_vec.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
                 let sum: f32 = src_vec.iter().sum();
                 let mean = sum / src_vec.len() as f32;
-                eprintln!("    source stats: min={:.6}, max={:.6}, mean={:.6}", min, max, mean);
+                eprintln!(
+                    "    source stats: min={:.6}, max={:.6}, mean={:.6}",
+                    min, max, mean
+                );
             }
         }
 
@@ -742,7 +756,10 @@ impl HiFTGenerator {
                 let max = audio_vec.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
                 let sum: f32 = audio_vec.iter().sum();
                 let mean = sum / audio_vec.len() as f32;
-                eprintln!("    [HiFT.forward] audio stats: min={:.6}, max={:.6}, mean={:.6}", min, max, mean);
+                eprintln!(
+                    "    [HiFT.forward] audio stats: min={:.6}, max={:.6}, mean={:.6}",
+                    min, max, mean
+                );
 
                 // Check for problems
                 if min < -1.0 || max > 1.0 {
@@ -778,7 +795,8 @@ impl HiFTGenerator {
             // Upsample
             let u = self.ups_rates[i];
             let (b, c, l) = x.dims3()?;
-            x = x.unsqueeze(3)?
+            x = x
+                .unsqueeze(3)?
                 .repeat((1, 1, 1, u))?
                 .reshape((b, c, l * u))?;
 
@@ -841,9 +859,14 @@ impl HiFTGenerator {
                 let max = vec.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
                 let sum: f32 = vec.iter().sum();
                 let mean = sum / vec.len() as f32;
-                eprintln!("    [decode] mag_log (before exp): min={:.6}, max={:.6}, mean={:.6}", min, max, mean);
+                eprintln!(
+                    "    [decode] mag_log (before exp): min={:.6}, max={:.6}, mean={:.6}",
+                    min, max, mean
+                );
                 if max > 50.0 {
-                    eprintln!("      ⚠️  CRITICAL: mag_log has very large values, exp() will overflow!");
+                    eprintln!(
+                        "      ⚠️  CRITICAL: mag_log has very large values, exp() will overflow!"
+                    );
                 }
             }
         }
@@ -863,7 +886,10 @@ impl HiFTGenerator {
                 let max = vec.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
                 let sum: f32 = vec.iter().sum();
                 let mean = sum / vec.len() as f32;
-                eprintln!("    [decode] magnitude (after exp): min={:.6}, max={:.6}, mean={:.6}", min, max, mean);
+                eprintln!(
+                    "    [decode] magnitude (after exp): min={:.6}, max={:.6}, mean={:.6}",
+                    min, max, mean
+                );
             }
         }
 

--- a/rust/native-server/src/lib.rs
+++ b/rust/native-server/src/lib.rs
@@ -1,4 +1,3 @@
-pub mod tts;
 pub mod audio;
 pub mod cosyvoice_flow;
 pub mod cosyvoice_llm;
@@ -7,4 +6,5 @@ pub mod hift;
 pub mod onnx_frontend;
 pub mod qwen;
 pub mod text_frontend;
+pub mod tts;
 pub mod utils;

--- a/rust/native-server/src/main.rs
+++ b/rust/native-server/src/main.rs
@@ -9,27 +9,21 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
+use candle_core::{Device, Tensor};
 use metrics::{counter, histogram};
 use metrics_exporter_prometheus::PrometheusBuilder;
-use std::{
-    env,
-    net::SocketAddr,
-    sync::Arc,
-    path::PathBuf,
-    time::Instant,
-};
+use std::{env, net::SocketAddr, path::PathBuf, sync::Arc, time::Instant};
 use tokio::signal;
 use tokio::sync::Mutex;
 use tower_http::trace::TraceLayer;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-use candle_core::{Device, Tensor};
 
 use shared::{config, ErrorResponse, HealthResponse, SynthesizeRequest};
 
-use cosyvoice_native_server::tts::NativeTtsEngine;
 use cosyvoice_native_server::audio::{self, MelConfig};
 use cosyvoice_native_server::text_frontend::text_normalize_english;
+use cosyvoice_native_server::tts::NativeTtsEngine;
 
 // Use jemalloc for better memory allocation performance
 #[global_allocator]
@@ -66,8 +60,8 @@ async fn main() -> anyhow::Result<()> {
     info!("Prometheus metrics recorder installed");
 
     // Get model directory
-    let model_dir = env::var("COSYVOICE_MODEL_DIR")
-        .unwrap_or_else(|_| config::DEFAULT_MODEL_DIR.to_string());
+    let model_dir =
+        env::var("COSYVOICE_MODEL_DIR").unwrap_or_else(|_| config::DEFAULT_MODEL_DIR.to_string());
 
     // Initialize Native TTS engine
     info!(model_dir = %model_dir, "Initializing Native TTS engine...");
@@ -80,11 +74,14 @@ async fn main() -> anyhow::Result<()> {
     // Initialize Tokenizer
     let tokenizer_path = PathBuf::from(&model_dir).join("tokenizer.json");
     if !tokenizer_path.exists() {
-        return Err(anyhow::anyhow!("Tokenizer file not found at {:?}", tokenizer_path));
+        return Err(anyhow::anyhow!(
+            "Tokenizer file not found at {:?}",
+            tokenizer_path
+        ));
     }
     let tokenizer = tokenizers::Tokenizer::from_file(&tokenizer_path)
         .map_err(|e| anyhow::anyhow!("Failed to load tokenizer: {}", e))?;
-     info!("Tokenizer initialized successfully");
+    info!("Tokenizer initialized successfully");
 
     let state = Arc::new(AppState {
         tts: Mutex::new(tts),
@@ -132,25 +129,43 @@ async fn synthesize_handler(
 
     let prompt_audio = match request.prompt_audio.as_deref() {
         Some(path) => path.to_string(),
-        None => return error_response(StatusCode::BAD_REQUEST, "prompt_audio is required".to_string()),
+        None => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "prompt_audio is required".to_string(),
+            )
+        }
     };
 
     let prompt_text = match request.prompt_text.as_deref() {
         Some(text) if !text.trim().is_empty() => text.to_string(),
-        Some(_) => return error_response(StatusCode::BAD_REQUEST, "prompt_text is empty".to_string()),
+        Some(_) => {
+            return error_response(StatusCode::BAD_REQUEST, "prompt_text is empty".to_string())
+        }
         None => request
             .speaker
             .clone()
             .unwrap_or_else(|| "Speak naturally in English.".to_string()),
     };
 
-    let prompt_segments = match text_normalize_english(&prompt_text, &state.tokenizer, false, true) {
+    let prompt_segments = match text_normalize_english(&prompt_text, &state.tokenizer, false, true)
+    {
         Ok(segments) => segments,
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("Prompt text normalize error: {e}")),
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Prompt text normalize error: {e}"),
+            )
+        }
     };
     let prompt_text = match prompt_segments.into_iter().next() {
         Some(text) if !text.trim().is_empty() => text,
-        _ => return error_response(StatusCode::BAD_REQUEST, "prompt_text normalized to empty".to_string()),
+        _ => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "prompt_text normalized to empty".to_string(),
+            )
+        }
     };
     let prompt_tokens = match encode_tokens(&state.tokenizer, &prompt_text) {
         Ok(tokens) => tokens,
@@ -158,38 +173,78 @@ async fn synthesize_handler(
     };
     let prompt_text_len = prompt_tokens.len();
 
-    let mut tts_segments = match text_normalize_english(&request.text, &state.tokenizer, true, true) {
+    let mut tts_segments = match text_normalize_english(&request.text, &state.tokenizer, true, true)
+    {
         Ok(segments) => segments,
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("Text normalize error: {e}")),
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Text normalize error: {e}"),
+            )
+        }
     };
     tts_segments.retain(|segment| !segment.trim().is_empty());
     if tts_segments.is_empty() {
-        return error_response(StatusCode::BAD_REQUEST, "text normalized to empty".to_string());
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "text normalized to empty".to_string(),
+        );
     }
 
-    let load_audio_result = tokio::task::spawn_blocking(move || audio::load_wav(prompt_audio)).await;
+    let load_audio_result =
+        tokio::task::spawn_blocking(move || audio::load_wav(prompt_audio)).await;
     let (prompt_samples, prompt_sr) = match load_audio_result {
         Ok(Ok(res)) => res,
-        Ok(Err(e)) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to load audio: {e}")),
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("Task join error: {e}")),
+        Ok(Err(e)) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to load audio: {e}"),
+            )
+        }
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Task join error: {e}"),
+            )
+        }
     };
 
     let prompt_16k = match audio::resample_audio(&prompt_samples, prompt_sr, 16000) {
         Ok(samples) => samples,
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("Resample to 16k failed: {e}")),
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Resample to 16k failed: {e}"),
+            )
+        }
     };
     let prompt_24k = match audio::resample_audio(&prompt_samples, prompt_sr, 24000) {
         Ok(samples) => samples,
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("Resample to 24k failed: {e}")),
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Resample to 24k failed: {e}"),
+            )
+        }
     };
 
     let prompt_speech_16k = match audio::whisper_log_mel_spectrogram(&prompt_16k, &Device::Cpu) {
         Ok(mel) => mel,
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("Whisper mel failed: {e}")),
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Whisper mel failed: {e}"),
+            )
+        }
     };
     let prompt_fbank = match audio::kaldi_fbank(&prompt_16k, 16000, &Device::Cpu) {
         Ok(fbank) => fbank,
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("Fbank failed: {e}")),
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Fbank failed: {e}"),
+            )
+        }
     };
 
     let device = {
@@ -197,38 +252,73 @@ async fn synthesize_handler(
         tts.device.clone()
     };
 
-    let mut prompt_speech_24k = match audio::mel_spectrogram(&prompt_24k, &MelConfig::cosyvoice3(), &device) {
-        Ok(mel) => mel,
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("24k mel failed: {e}")),
-    };
+    let mut prompt_speech_24k =
+        match audio::mel_spectrogram(&prompt_24k, &MelConfig::cosyvoice3(), &device) {
+            Ok(mel) => mel,
+            Err(e) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("24k mel failed: {e}"),
+                )
+            }
+        };
 
     let mut tts = state.tts.lock().await;
-    let (mut prompt_speech_tokens, speaker_embedding) = match tts.process_prompt_tensors(&prompt_speech_16k, &prompt_fbank) {
-        Ok(res) => res,
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("Prompt processing failed: {e}")),
-    };
+    let (mut prompt_speech_tokens, speaker_embedding) =
+        match tts.process_prompt_tensors(&prompt_speech_16k, &prompt_fbank) {
+            Ok(res) => res,
+            Err(e) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Prompt processing failed: {e}"),
+                )
+            }
+        };
 
     let mel_len = match prompt_speech_24k.dim(2) {
         Ok(len) => len,
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("Prompt mel shape error: {e}")),
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Prompt mel shape error: {e}"),
+            )
+        }
     };
     let token_len = match prompt_speech_tokens.dim(1) {
         Ok(len) => len,
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("Prompt token shape error: {e}")),
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Prompt token shape error: {e}"),
+            )
+        }
     };
     let aligned_token_len = usize::min(mel_len / 2, token_len);
     if aligned_token_len == 0 {
-        return error_response(StatusCode::BAD_REQUEST, "prompt audio produced no usable tokens".to_string());
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "prompt audio produced no usable tokens".to_string(),
+        );
     }
 
     if aligned_token_len != token_len {
         prompt_speech_24k = match prompt_speech_24k.narrow(2, 0, aligned_token_len * 2) {
             Ok(mel) => mel,
-            Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("Prompt mel align failed: {e}")),
+            Err(e) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Prompt mel align failed: {e}"),
+                )
+            }
         };
         prompt_speech_tokens = match prompt_speech_tokens.narrow(1, 0, aligned_token_len) {
             Ok(tokens) => tokens,
-            Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("Prompt token align failed: {e}")),
+            Err(e) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Prompt token align failed: {e}"),
+                )
+            }
         };
     }
 
@@ -250,11 +340,21 @@ async fn synthesize_handler(
             &device,
         ) {
             Ok(t) => t,
-            Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("Text tensor error: {e}")),
+            Err(e) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Text tensor error: {e}"),
+                )
+            }
         };
         let text_embeds = match tts.llm.embed_text_tokens(&text_tensor) {
             Ok(embeds) => embeds,
-            Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("Text embed error: {e}")),
+            Err(e) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Text embed error: {e}"),
+                )
+            }
         };
 
         let segment_samples = match tts.synthesize_full_with_prompt_len(
@@ -266,7 +366,12 @@ async fn synthesize_handler(
             25,
         ) {
             Ok(samples) => samples,
-            Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("Synthesis failed: {e}")),
+            Err(e) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Synthesis failed: {e}"),
+                )
+            }
         };
 
         all_samples.extend_from_slice(&segment_samples);

--- a/rust/native-server/src/qwen.rs
+++ b/rust/native-server/src/qwen.rs
@@ -1,6 +1,6 @@
 use candle_core::{DType, Device, Result, Tensor};
-use candle_nn::{linear, linear_no_bias, Activation, Linear, Module, VarBuilder};
 use candle_nn::ops::sdpa;
+use candle_nn::{linear, linear_no_bias, Activation, Linear, Module, VarBuilder};
 use candle_transformers::utils::repeat_kv;
 use std::sync::Arc;
 
@@ -312,7 +312,10 @@ impl Model {
         let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
         let vb_l = vb_m.pp("layers");
         for layer_idx in 0..cfg.num_hidden_layers {
-            eprintln!("Qwen2: Loading layer {}/{}...", layer_idx, cfg.num_hidden_layers);
+            eprintln!(
+                "Qwen2: Loading layer {}/{}...",
+                layer_idx, cfg.num_hidden_layers
+            );
             let layer = DecoderLayer::new(rotary_emb.clone(), cfg, vb_l.pp(layer_idx))?;
             layers.push(layer)
         }

--- a/rust/native-server/src/qwen.rs
+++ b/rust/native-server/src/qwen.rs
@@ -1,5 +1,6 @@
 use candle_core::{DType, Device, Result, Tensor};
 use candle_nn::{linear, linear_no_bias, Activation, Linear, Module, VarBuilder};
+use candle_nn::ops::sdpa;
 use candle_transformers::utils::repeat_kv;
 use std::sync::Arc;
 
@@ -137,14 +138,7 @@ impl Attention {
         let v_proj = linear(hidden_sz, num_kv_heads * head_dim, vb.pp("v_proj"))?;
         let o_proj = linear_no_bias(num_heads * head_dim, hidden_sz, vb.pp("o_proj"))?;
 
-        let use_flash_attn = if cfg!(feature = "cuda") {
-            // Check if device is CUDA and supports it (could be dynamic)
-            // For now, assume true if cuda feature is on and we are using CUDA device
-            // TODO: Implement Flash Attention call
-            false
-        } else {
-            false
-        };
+        let use_flash_attn = vb.device().is_cuda() || vb.device().is_metal();
 
         Ok(Self {
             q_proj,
@@ -198,24 +192,48 @@ impl Attention {
         };
         self.kv_cache = Some((key_states.clone(), value_states.clone()));
 
-        // Flash Attention Logic
+        let key_states = repeat_kv(key_states, self.num_kv_groups)?.contiguous()?;
+        let value_states = repeat_kv(value_states, self.num_kv_groups)?.contiguous()?;
+        let scale = 1f64 / f64::sqrt(self.head_dim as f64);
+        let scale_f32 = scale as f32;
+
+        // SDPA path (fused attention) with fallback to the manual path.
         let attn_output = if self.use_flash_attn {
-            panic!("Flash Attention not supported without cuda feature");
+            match sdpa(
+                &query_states,
+                &key_states,
+                &value_states,
+                attention_mask,
+                false,
+                scale_f32,
+                1.0,
+            ) {
+                Ok(attn) => attn
+                    .transpose(1, 2)?
+                    .reshape((b_sz, q_len, self.hidden_size))?,
+                Err(_) => {
+                    let attn_weights =
+                        (query_states.matmul(&key_states.transpose(2, 3)?)? * scale)?;
+                    let attn_weights = match attention_mask {
+                        None => attn_weights,
+                        Some(mask) => attn_weights.broadcast_add(mask)?,
+                    };
+                    let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
+                    attn_weights
+                        .matmul(&value_states)?
+                        .transpose(1, 2)?
+                        .reshape((b_sz, q_len, self.hidden_size))?
+                }
+            }
         } else {
-            let key_states = repeat_kv(key_states, self.num_kv_groups)?.contiguous()?;
-            let value_states = repeat_kv(value_states, self.num_kv_groups)?.contiguous()?;
-
-            let scale = 1f64 / f64::sqrt(self.head_dim as f64);
             let attn_weights = (query_states.matmul(&key_states.transpose(2, 3)?)? * scale)?;
-
             let attn_weights = match attention_mask {
                 None => attn_weights,
                 Some(mask) => attn_weights.broadcast_add(mask)?,
             };
             let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
-            let attn_weights = attn_weights.matmul(&value_states)?;
-
             attn_weights
+                .matmul(&value_states)?
                 .transpose(1, 2)?
                 .reshape((b_sz, q_len, self.hidden_size))?
         };

--- a/rust/native-server/src/text_frontend.rs
+++ b/rust/native-server/src/text_frontend.rs
@@ -168,7 +168,11 @@ fn words_under_1000(value: u16) -> String {
     if remainder == 0 {
         format!("{} hundred", unit_word(hundreds))
     } else {
-        format!("{} hundred and {}", unit_word(hundreds), words_under_100(remainder))
+        format!(
+            "{} hundred and {}",
+            unit_word(hundreds),
+            words_under_100(remainder)
+        )
     }
 }
 

--- a/rust/native-server/src/utils.rs
+++ b/rust/native-server/src/utils.rs
@@ -52,15 +52,16 @@ impl STFT {
 }
 
 pub struct StftModule {
-    _n_fft: usize,
+    n_fft: usize,
     hop_length: usize,
     filters_real: Tensor, // [n_fft/2 + 1, 1, n_fft]
     filters_imag: Tensor, // [n_fft/2 + 1, 1, n_fft]
+    center: bool,
     _device: Device,
 }
 
 impl StftModule {
-    pub fn new(n_fft: usize, hop_length: usize, device: &Device) -> Result<Self> {
+    pub fn new(n_fft: usize, hop_length: usize, center: bool, device: &Device) -> Result<Self> {
         let window = hann_window(n_fft, device)?; // [n_fft]
         let (dft_real, dft_imag) = dft_matrix(n_fft, device)?; // [n_fft/2+1, n_fft]
 
@@ -74,20 +75,27 @@ impl StftModule {
         let filters_imag = filters_imag.unsqueeze(1)?;
 
         Ok(Self {
-            _n_fft: n_fft,
+            n_fft,
             hop_length,
             filters_real,
             filters_imag,
+            center,
             _device: device.clone(),
         })
     }
 
     pub fn transform(&self, x: &Tensor) -> Result<(Tensor, Tensor)> {
-        // x: [Batch, Time] -> need [Batch, 1, Time] for conv1d
-        let x_unsqueezed = if x.rank() == 2 {
-             x.unsqueeze(1)?
+        let x_in = if self.center {
+            reflect_pad_1d(x, self.n_fft / 2)?
         } else {
-             x.clone()
+            x.clone()
+        };
+
+        // x: [Batch, Time] -> need [Batch, 1, Time] for conv1d
+        let x_unsqueezed = if x_in.rank() == 2 {
+             x_in.unsqueeze(1)?
+        } else {
+             x_in
         };
 
         let real = x_unsqueezed.conv1d(
@@ -108,16 +116,20 @@ impl StftModule {
 use candle_nn::{ConvTranspose1d, ConvTranspose1dConfig, Module};
 
 pub struct InverseStftModule {
-    _n_fft: usize,
-    _hop_length: usize,
+    n_fft: usize,
+    hop_length: usize,
+    window: Vec<f32>,
     conv_real: ConvTranspose1d,
     conv_imag: ConvTranspose1d,
+    center: bool,
     _device: Device,
 }
 
 impl InverseStftModule {
-    pub fn new(n_fft: usize, hop_length: usize, device: &Device) -> Result<Self> {
-        let _window = hann_window(n_fft, device)?; // [n_fft]
+    pub fn new(n_fft: usize, hop_length: usize, center: bool, device: &Device) -> Result<Self> {
+        let window = hann_window(n_fft, device)?; // [n_fft]
+        let window_cpu = hann_window(n_fft, &Device::Cpu)?;
+        let window_vec = window_cpu.to_vec1::<f32>()?;
 
         let n_bins = n_fft / 2 + 1;
         let mut real_weights = Vec::with_capacity(n_bins * n_fft);
@@ -173,10 +185,12 @@ impl InverseStftModule {
         let conv_imag = ConvTranspose1d::new(w_imag, None, cfg);
 
         Ok(Self {
-            _n_fft: n_fft,
-            _hop_length: hop_length,
+            n_fft,
+            hop_length,
+            window: window_vec,
             conv_real,
             conv_imag,
+            center,
             _device: device.clone(),
         })
     }
@@ -197,10 +211,92 @@ impl InverseStftModule {
         // Sum components
         let y = (y_real + y_imag)?;
 
+        let frames = magnitude.dim(2)?;
+        let out_len = (frames - 1) * self.hop_length + self.n_fft;
+        let mut window_sums = vec![0.0f32; out_len];
+        for frame in 0..frames {
+            let start = frame * self.hop_length;
+            for n in 0..self.n_fft {
+                let idx = start + n;
+                if idx < out_len {
+                    let win = self.window[n];
+                    window_sums[idx] += win * win;
+                }
+            }
+        }
+        for v in window_sums.iter_mut() {
+            if *v < 1e-8 {
+                *v = 1.0;
+            }
+        }
+
+        let window_sums = Tensor::from_vec(window_sums, (1, 1, out_len), y.device())?;
+        let window_sums = window_sums.broadcast_as(y.shape())?;
+        let y = y.broadcast_div(&window_sums)?;
+
         // Output might be padded due to Centered STFT assumptions in PyTorch?
-        // HiFT generator output is `x`. User handles cropping.
+        // Match torch.istft(center=True) by trimming n_fft/2 on both sides.
+        if self.center {
+            let pad = self.n_fft / 2;
+            if out_len > 2 * pad {
+                return y.narrow(2, pad, out_len - 2 * pad);
+            }
+        }
+
         Ok(y)
     }
+}
+
+fn reflect_pad_1d(x: &Tensor, pad: usize) -> Result<Tensor> {
+    if pad == 0 {
+        return Ok(x.clone());
+    }
+
+    let device = x.device();
+    let (b, c, t, rank) = if x.rank() == 2 {
+        let (b, t) = x.dims2()?;
+        (b, 1usize, t, 2usize)
+    } else if x.rank() == 3 {
+        let (b, c, t) = x.dims3()?;
+        (b, c, t, 3usize)
+    } else {
+        return Err(candle_core::Error::msg("reflect_pad_1d expects rank-2 or rank-3 input"));
+    };
+
+    if t <= pad {
+        return Err(candle_core::Error::msg("reflect_pad_1d pad >= signal length"));
+    }
+
+    let x_cpu = x.to_device(&Device::Cpu)?;
+    let x_vec = x_cpu.flatten_all()?.to_vec1::<f32>()?;
+
+    let out_t = t + 2 * pad;
+    let mut out = Vec::with_capacity(b * c * out_t);
+
+    for bi in 0..b {
+        for ci in 0..c {
+            let offset = (bi * c + ci) * t;
+            // Left pad
+            for i in 0..pad {
+                let idx = pad - i;
+                out.push(x_vec[offset + idx]);
+            }
+            // Original
+            out.extend_from_slice(&x_vec[offset..offset + t]);
+            // Right pad
+            for i in 0..pad {
+                let idx = t - 2 - i;
+                out.push(x_vec[offset + idx]);
+            }
+        }
+    }
+
+    let shape = if rank == 2 {
+        (b, out_t)
+    } else {
+        (b, c, out_t)
+    };
+    Tensor::from_vec(out, shape, device)
 }
 
 /// Generates Hann Window of size N

--- a/rust/native-server/src/utils.rs
+++ b/rust/native-server/src/utils.rs
@@ -291,12 +291,11 @@ fn reflect_pad_1d(x: &Tensor, pad: usize) -> Result<Tensor> {
         }
     }
 
-    let shape = if rank == 2 {
-        (b, out_t)
+    if rank == 2 {
+        Tensor::from_vec(out, (b, out_t), device)
     } else {
-        (b, c, out_t)
-    };
-    Tensor::from_vec(out, shape, device)
+        Tensor::from_vec(out, (b, c, out_t), device)
+    }
 }
 
 /// Generates Hann Window of size N

--- a/rust/native-server/src/utils.rs
+++ b/rust/native-server/src/utils.rs
@@ -93,9 +93,9 @@ impl StftModule {
 
         // x: [Batch, Time] -> need [Batch, 1, Time] for conv1d
         let x_unsqueezed = if x_in.rank() == 2 {
-             x_in.unsqueeze(1)?
+            x_in.unsqueeze(1)?
         } else {
-             x_in
+            x_in
         };
 
         let real = x_unsqueezed.conv1d(
@@ -127,7 +127,7 @@ pub struct InverseStftModule {
 
 impl InverseStftModule {
     pub fn new(n_fft: usize, hop_length: usize, center: bool, device: &Device) -> Result<Self> {
-        let window = hann_window(n_fft, device)?; // [n_fft]
+        let _window = hann_window(n_fft, device)?; // [n_fft]
         let window_cpu = hann_window(n_fft, &Device::Cpu)?;
         let window_vec = window_cpu.to_vec1::<f32>()?;
 
@@ -260,11 +260,15 @@ fn reflect_pad_1d(x: &Tensor, pad: usize) -> Result<Tensor> {
         let (b, c, t) = x.dims3()?;
         (b, c, t, 3usize)
     } else {
-        return Err(candle_core::Error::msg("reflect_pad_1d expects rank-2 or rank-3 input"));
+        return Err(candle_core::Error::msg(
+            "reflect_pad_1d expects rank-2 or rank-3 input",
+        ));
     };
 
     if t <= pad {
-        return Err(candle_core::Error::msg("reflect_pad_1d pad >= signal length"));
+        return Err(candle_core::Error::msg(
+            "reflect_pad_1d pad >= signal length",
+        ));
     }
 
     let x_cpu = x.to_device(&Device::Cpu)?;

--- a/rust/native-server/tests/llm_length_parity.rs
+++ b/rust/native-server/tests/llm_length_parity.rs
@@ -106,14 +106,24 @@ fn llm_length_parity() -> Result<()> {
         .unwrap_or_else(|_| "pretrained_models/Fun-CosyVoice3-0.5B".to_string());
     let model_path = PathBuf::from(&model_dir);
     if !model_path.exists() {
-        eprintln!("Skipping parity test (model_dir not found at {}).", model_dir);
+        eprintln!(
+            "Skipping parity test (model_dir not found at {}).",
+            model_dir
+        );
         return Ok(());
     }
 
-    let tokenizer_path = std::env::var("COSYVOICE_TOKENIZER_PATH")
-        .unwrap_or_else(|_| model_path.join("tokenizer.json").to_string_lossy().to_string());
+    let tokenizer_path = std::env::var("COSYVOICE_TOKENIZER_PATH").unwrap_or_else(|_| {
+        model_path
+            .join("tokenizer.json")
+            .to_string_lossy()
+            .to_string()
+    });
     if !Path::new(&tokenizer_path).exists() {
-        eprintln!("Skipping parity test (tokenizer not found at {}).", tokenizer_path);
+        eprintln!(
+            "Skipping parity test (tokenizer not found at {}).",
+            tokenizer_path
+        );
         return Ok(());
     }
 

--- a/rust/native-server/tests/text_frontend_parity.rs
+++ b/rust/native-server/tests/text_frontend_parity.rs
@@ -86,7 +86,10 @@ fn english_text_normalize_parity() -> Result<()> {
     let tokenizer_path = std::env::var("COSYVOICE_TOKENIZER_PATH")
         .unwrap_or_else(|_| "pretrained_models/Fun-CosyVoice3-0.5B/tokenizer.json".to_string());
     if !Path::new(&tokenizer_path).exists() {
-        eprintln!("Skipping parity test (tokenizer not found at {}).", tokenizer_path);
+        eprintln!(
+            "Skipping parity test (tokenizer not found at {}).",
+            tokenizer_path
+        );
         return Ok(());
     }
 

--- a/tools/profile_tts.py
+++ b/tools/profile_tts.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+import argparse
+import io
+import json
+import os
+import statistics
+import sys
+import time
+import wave
+from urllib import request as urllib_request
+from urllib.error import HTTPError, URLError
+
+
+def _repo_root() -> str:
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+
+
+def _add_repo_to_path() -> None:
+    root = _repo_root()
+    if root not in sys.path:
+        sys.path.insert(0, root)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Profile CosyVoice TTS in Python or via the HTTP server."
+    )
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    py = sub.add_parser("python", help="Run profiling via the Python pipeline.")
+    py.add_argument("--model-dir", required=True)
+    py.add_argument("--text", required=True)
+    py.add_argument("--prompt-audio", required=True)
+    py.add_argument("--prompt-text", default="")
+    py.add_argument("--instruct-text", default="")
+    py.add_argument("--speed", type=float, default=1.0)
+    py.add_argument("--iterations", type=int, default=3)
+    py.add_argument("--warmup", type=int, default=2)
+    py.add_argument("--stream", action="store_true")
+    py.add_argument("--load-trt", action="store_true")
+    py.add_argument("--load-vllm", action="store_true")
+    py.add_argument("--fp16", action="store_true")
+    py.add_argument("--trt-concurrent", type=int, default=1)
+    py.add_argument("--use-rl", action="store_true")
+
+    srv = sub.add_parser("server", help="Run profiling against the HTTP server.")
+    srv.add_argument("--url", required=True)
+    srv.add_argument("--text", required=True)
+    srv.add_argument("--prompt-audio", required=True)
+    srv.add_argument("--prompt-text", default="")
+    srv.add_argument("--speaker", default="")
+    srv.add_argument("--speed", type=float, default=1.0)
+    srv.add_argument("--iterations", type=int, default=3)
+    srv.add_argument("--warmup", type=int, default=1)
+    srv.add_argument("--timeout", type=float, default=120.0)
+
+    parser.add_argument("--output", default="")
+    return parser.parse_args()
+
+
+def _duration_from_wav(wav_bytes: bytes, headers) -> float:
+    header_val = headers.get("x-audio-duration")
+    if header_val:
+        try:
+            return float(header_val)
+        except ValueError:
+            pass
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wav_file:
+        frames = wav_file.getnframes()
+        rate = wav_file.getframerate()
+    return frames / float(rate) if rate else 0.0
+
+
+def _stats(values):
+    if not values:
+        return {"avg": None, "median": None, "min": None, "max": None}
+    return {
+        "avg": statistics.mean(values),
+        "median": statistics.median(values),
+        "min": min(values),
+        "max": max(values),
+    }
+
+
+def _summarize(samples):
+    return {
+        "iterations": len(samples),
+        "ftl": _stats([s["ftl"] for s in samples if s["ftl"] is not None]),
+        "rtf": _stats([s["rtf"] for s in samples if s["rtf"] is not None]),
+        "throughput": _stats(
+            [s["throughput"] for s in samples if s["throughput"] is not None]
+        ),
+        "total_time": _stats([s["total_time"] for s in samples]),
+        "audio_secs": _stats([s["audio_secs"] for s in samples]),
+    }
+
+
+def _run_python(args: argparse.Namespace) -> dict:
+    _add_repo_to_path()
+    from cosyvoice.cli.cosyvoice import AutoModel
+
+    model_kwargs = {
+        "model_dir": args.model_dir,
+        "load_trt": args.load_trt,
+        "load_vllm": args.load_vllm,
+        "fp16": args.fp16,
+        "trt_concurrent": args.trt_concurrent,
+        "use_rl": args.use_rl,
+    }
+
+    load_start = time.perf_counter()
+    model = AutoModel(**model_kwargs)
+    load_time = time.perf_counter() - load_start
+
+    if args.instruct_text:
+        infer = lambda: model.inference_instruct2(
+            args.text,
+            args.instruct_text,
+            args.prompt_audio,
+            stream=args.stream,
+            speed=args.speed,
+        )
+    else:
+        infer = lambda: model.inference_zero_shot(
+            args.text,
+            args.prompt_text,
+            args.prompt_audio,
+            stream=args.stream,
+            speed=args.speed,
+        )
+
+    for _ in range(args.warmup):
+        for _ in infer():
+            pass
+
+    samples = []
+    for _ in range(args.iterations):
+        start = time.perf_counter()
+        ftl = None
+        audio_secs = 0.0
+        for output in infer():
+            if ftl is None:
+                ftl = time.perf_counter() - start
+            audio_secs += output["tts_speech"].shape[1] / model.sample_rate
+        total_time = time.perf_counter() - start
+        rtf = total_time / audio_secs if audio_secs > 0 else None
+        throughput = audio_secs / total_time if total_time > 0 else None
+        samples.append(
+            {
+                "ftl": ftl,
+                "rtf": rtf,
+                "throughput": throughput,
+                "total_time": total_time,
+                "audio_secs": audio_secs,
+            }
+        )
+
+    return {
+        "mode": "python",
+        "load_time": load_time,
+        "samples": samples,
+        "summary": _summarize(samples),
+    }
+
+
+def _post_json(url: str, payload: dict, timeout: float):
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib_request.Request(
+        url, data=body, headers={"Content-Type": "application/json"}
+    )
+    start = time.perf_counter()
+    resp = urllib_request.urlopen(req, timeout=timeout)
+    ttfb = time.perf_counter() - start
+    data = resp.read()
+    total = time.perf_counter() - start
+    return resp, data, ttfb, total
+
+
+def _run_server(args: argparse.Namespace) -> dict:
+    payload = {
+        "text": args.text,
+        "prompt_audio": args.prompt_audio,
+        "prompt_text": args.prompt_text or None,
+        "speaker": args.speaker or None,
+        "speed": args.speed,
+    }
+    payload = {k: v for k, v in payload.items() if v is not None}
+
+    for _ in range(args.warmup):
+        _post_json(args.url, payload, args.timeout)
+
+    samples = []
+    for _ in range(args.iterations):
+        resp, data, ttfb, total = _post_json(args.url, payload, args.timeout)
+        audio_secs = _duration_from_wav(data, resp.headers)
+        rtf = total / audio_secs if audio_secs > 0 else None
+        throughput = audio_secs / total if total > 0 else None
+        samples.append(
+            {
+                "ftl": ttfb,
+                "rtf": rtf,
+                "throughput": throughput,
+                "total_time": total,
+                "audio_secs": audio_secs,
+            }
+        )
+
+    return {
+        "mode": "server",
+        "samples": samples,
+        "summary": _summarize(samples),
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        if args.mode == "python":
+            result = _run_python(args)
+        else:
+            result = _run_server(args)
+    except HTTPError as exc:
+        sys.stderr.write(f"HTTP error {exc.code}: {exc.read().decode('utf-8')}\n")
+        return 1
+    except URLError as exc:
+        sys.stderr.write(f"Network error: {exc}\n")
+        return 1
+
+    output = json.dumps(result, indent=2)
+    print(output)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(output)
+            f.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #91

## Summary
Optimize TTS inference and profiling across Python + Rust, reduce PyO3 overhead, and enable ORT/attention tuning.

## Changes
- Add unified profiling harness and benchmark CLI output.
- Tighten Python inference/ORT frontend paths and LLM attention selection.
- Optimize Rust bridge/native hot paths (PyO3 conversion, ORT opts, SDPA, debug gating) and apply rustfmt/clippy fixes.