### PR TITLE
feat: Configure candle-flash-attn

### DIFF
--- a/rust/native-server/Cargo.toml
+++ b/rust/native-server/Cargo.toml
@@ -48,5 +48,6 @@ cuda = [
     "candle-core/cuda",
     "candle-nn/cuda",
     "candle-transformers/cuda",
+    "candle-transformers/flash-attn",
     "candle-kernels",
 ]


### PR DESCRIPTION
Enables the `flash-attn` feature for `candle-transformers` in the `cuda` profile of `native-server`. This configuration includes the `candle-flash-attn` crate for optimized attention kernels on supported GPUs.

Closes #107